### PR TITLE
build-up correct namespace for import

### DIFF
--- a/pyvcdr/__init__.py
+++ b/pyvcdr/__init__.py
@@ -1,1 +1,3 @@
+from .pyvcdr import VcdR
+
 name = "pyvcdr"


### PR DESCRIPTION
When I try to import like written in your example, the class VcdR is not found.
It only works when pyvcdr.py is placed as source file in the project folder.

In case it is used as module (own folder) or installed via pip it fails.
Reason is, that file pyvcdr.py contains a class with different name: VcdR

So you either have to double the file name for import:
```
import pyvcdr
foo = pyvcdr.pyvcdr.VcdR()
```

or fix that namespace issue in the __init__.py