### PR TITLE
fix(process_cmd): fix issue when no newline char

### DIFF
--- a/pyvcdr/pyvcdr.py
+++ b/pyvcdr/pyvcdr.py
@@ -52,6 +52,8 @@ class VcdR(object):
             space_index = cmd_line.find('\n')
         if space_index == -1:
             space_index = cmd_line.find('\r')
+        if space_index == -1:
+            space_index = len(cmd_line)
 
         cmd = cmd_line[1:space_index]
         cmd.strip()


### PR DESCRIPTION
if `parse_str` is used then `cmd_line` won't end with a newline character and parsing will fail. this is a small patch to fix this